### PR TITLE
Fixed Reference to config.secret that should be config.pass

### DIFF
--- a/lib/jsPAPI.js
+++ b/lib/jsPAPI.js
@@ -26,6 +26,11 @@ var jsPAPI = function(config = {}, customModules = false) {
         'bibSearchKW',
         'bibHoldingsGet',
         'collectionsGet',
+        'patronAccountGet',
+        'holdRequestCreate',
+        'holdRequestCancel',
+        'patronHoldRequestsGet',
+        'patronItemsOutGet',
     ];
 
     // Load modules

--- a/lib/modules/call.js
+++ b/lib/modules/call.js
@@ -75,7 +75,7 @@ module.exports = function(parent) {
         url = url + '/' + endpoint;
 
         // Generate date and signature elements
-        sig = parent._buildSignature(config.method.toUpperCase(), url, config.secret);
+        sig = parent._buildSignature(config.method.toUpperCase(), url, config.pass);
 
         // Build Axios Config
         var xhrCfg = {

--- a/lib/modules/holdRequestCancel.js
+++ b/lib/modules/holdRequestCancel.js
@@ -1,0 +1,45 @@
+/** 
+ * @module holdRequestCancel
+ */
+
+/**
+ * Cancel a Patrons Hold
+ *
+ * @param {int|string} Barcode          - The barcode of the User
+ * @param {int|string} Password  				- The password of the User
+ * @param {int|string} RequestId        - The Id of the Hold Request to be canceled
+ * @param {int|string} WorkstationID  	- The ID of the workstation from which the request is being canceled.  (Use 1)
+ * @param {int|string} UserID           - The Id of the user of the workstation.  Not patron userid.  (Use 1).
+ * 
+ * 
+ * @returns {promise}
+ * 
+ * @example myPapi.holdRequestCancel(Barcode, Password)
+ *      .then(function(response) {
+ *          console.log(response.data);
+ *      });
+ *
+ @example myPapi.holdRequestCancel(Barcode, Password, RequestId)
+ *      .then(function(response) {
+ *          console.log(response.data);
+ *      });
+ */
+
+module.exports = function(parent) {
+    parent.holdRequestCancel = function(barcode, password, requestID, WorkstationID = 1, UserID = 1) {
+        url = 'patron/' + barcode + '/holdrequests/' + requestID + '/cancelled';
+        url += '?wsid=' + WorkstationID + '&userid=' + UserID;
+    		    		
+    		
+        return parent.call( url,
+            { method: 'PUT', pass: password, 
+            	"wsid": WorkstationID,
+            	"userid": UserID,},
+       				{
+            	"wsid": WorkstationID,
+            	"userid": UserID,
+            	});
+        
+    }
+    return parent;
+}

--- a/lib/modules/holdRequestCreate.js
+++ b/lib/modules/holdRequestCreate.js
@@ -1,0 +1,45 @@
+/** 
+ * @module holdRequestCreate
+ */
+
+/**
+ * Create a patron hold on an item
+ *
+ * @param {int|string} PatronID     - The Id of the patron placing the hold.  (Seperate from Barcode)
+ * @param {int|string} BibID				- The internal id of the item being put on hold
+ * @param {int|string} RequestingOrgID - ID of the Organization making the request.
+ * @param {int|string} PickupOrgID     - ID of the organization at which the item will be picked up
+ * 
+ * @returns {promise}
+ * 
+ * @example myPapi.holdRequestCreate(PatronID, BibID, RequestingOrgId)
+ *      .then(function(response) {
+ *          console.log(response.data);
+ *      });
+ *
+ @example myPapi.holdRequestCreate(PatronID, BibID, RequestingOrgId, PickupOrgID)
+ *      .then(function(response) {
+ *          console.log(response.data);
+ *      });
+ */
+
+module.exports = function(parent) {
+    parent.holdRequestCreate = function(PatronID, BibID, RequestingOrgID, PickupOrgID = RequestingOrgID, 
+    WorkstationID = 1, UserID = 1) {
+        url = 'holdrequest'
+    		
+    		
+    		
+        return parent.call( url,
+            { method: 'POST' },
+            { "PatronID": PatronID , 
+            	"BibId": BibID,
+            	"PickupOrgID": PickupOrgID,
+            	"RequestingOrgID": RequestingOrgID,
+            	"WorkstationID": WorkstationID,
+            	"UserID": UserID,
+            	});
+        
+    }
+    return parent;
+}

--- a/lib/modules/patronAccountGet.js
+++ b/lib/modules/patronAccountGet.js
@@ -1,0 +1,28 @@
+/** 
+ * @module patronAccountGet
+ */
+
+/**
+ * Retrieves Users Fines and Fees
+ *
+ * @param {int|string} barcode   - patron barcode/library card #
+ * @param {int|string} password  - patron password
+ * @param {string} status						   - outstanding|reconciled
+ * 
+ * @returns {promise}
+ * 
+ * @example myPapi.patronAccountGet('patronBarcode', 'status')
+ *      .then(function(response) {
+ *          console.log(response.data);
+ *      });
+ */
+
+module.exports = function(parent) {
+    parent.patronAccountGet = function(barcode, password, status = 'outstanding') {
+    		console.log(status);
+        return parent.call( ('patron/'+ barcode + '/account/' + status),
+            { method: 'GET', pass: password, }/*,
+            { "Barcode": barcode , "Password": password}*/);
+    }
+    return parent;
+}

--- a/lib/modules/patronHoldRequestsGet.js
+++ b/lib/modules/patronHoldRequestsGet.js
@@ -1,0 +1,34 @@
+/** 
+ * @module patronHoldRequestsGet
+ */
+
+/**
+ * Get a Patrons Holds
+ *
+ * @param {int|string} Barcode          - The barcode of the User
+ * @param {int|string} Password  				- The password of the User
+ * @param {int|string} SatusOrId        - The status of the Holds or the ID of the individual hold.
+ * 
+ * Satus can be one of the following: (ALL|INACTIVE|PENDING|SHIPPED|HELD|NOTSUPPLIED|UNCLAIMED|EXPIRED|CANCELLED)
+ * 
+ * @returns {promise}
+ * 
+ * @example myPapi.patronHoldRequestsGet(Barcode, Password)
+ *      .then(function(response) {
+ *          console.log(response.data);
+ *      });
+ *
+ @example myPapi.patronHoldRequestsGet(Barcode, Password, StatusOrId)
+ *      .then(function(response) {
+ *          console.log(response.data);
+ *      });
+ */
+
+module.exports = function(parent) {
+    parent.patronHoldRequestsGet = function(barcode, password, statusOrId = 'all') {
+        url = 'patron/' + barcode + '/holdrequests/' + statusOrId;    		
+        return parent.call( url,
+            {  method: 'GET', "pass": password,});        
+    }
+    return parent;
+}

--- a/lib/modules/patronItemsOutGet.js
+++ b/lib/modules/patronItemsOutGet.js
@@ -1,0 +1,34 @@
+/** 
+ * @module patronItemsOutGet.js
+ */
+
+/**
+ * Get a Patrons Items Out
+ *
+ * @param {int|string} Barcode          - The barcode of the User
+ * @param {int|string} Password  				- The password of the User
+ * @param {string} Satus								- The Status of the item
+ * 
+ * Satus can be one of the following: (ALL|OVERDUE|LOST)
+ * 
+ * @returns {promise}
+ * 
+ * @example myPapi.patronItemsOutGet(Barcode, Password)
+ *      .then(function(response) {
+ *          console.log(response.data);
+ *      });
+ *
+ @example myPapi.patronItemsOutGet(Barcode, Password, Status)
+ *      .then(function(response) {
+ *          console.log(response.data);
+ *      });
+ */
+
+module.exports = function(parent) {
+    parent.patronItemsOutGet = function(barcode, password, status = 'all') {
+        url = 'patron/' + barcode + '/itemsout/' + status;    		
+        return parent.call( url,
+            {  method: 'GET', "pass": password,});        
+    }
+    return parent;
+}


### PR DESCRIPTION
When the signature is being built, it will for some functions require the users password. Changing config.secret to config.pass to bring it inline with the
documented parameters of the call function.